### PR TITLE
Add ClickPerSecond handler. Move away from StartApp.simple

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
         "evancz/elm-html": "4.0.2 <= v < 5.0.0",
         "evancz/start-app": "2.0.2 <= v < 3.0.0"
     },

--- a/src/CookieClicker.elm
+++ b/src/CookieClicker.elm
@@ -3,36 +3,39 @@ module CookieClicker where
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
-import Signal exposing (Signal, Address)
+import Signal exposing (Signal, Address, map)
 import String
-
+import Time exposing (second, every)
+import Effects exposing (..)
 -- Model
 
 type State = Play | Pause
 
 type alias Game =
-    { points : Int -- aka Cookies Clicked
+    { clicks : Int -- aka Cookies Clicked
     , level : Int
+    , cps_multiplier : Float
     } 
-
-type alias Award = 
-    { id : Int
-    , title : String
-    }
 
 initGame : Game
 initGame = 
-    { points = 0
+    { clicks = 0
     , level = 1
+    , cps_multiplier = 1.7
     }
 
 -- Update
 
 type Action = Increment
 
-clickCookie action game =
+ticker : Signal Action
+ticker = Signal.map (always Increment) (Time.every Time.second)
+
+update : Action -> Game -> (Game, Effects.Effects Action)
+update action game =
     case action of
-        Increment -> { game | points = game.points + 1 }
+        Increment -> ( {game | clicks = game.clicks + round (1 * game.cps_multiplier)}, Effects.none )
+        -- TODO: Consider changing `round` to floor or ceiling
 
 -- View
 
@@ -41,5 +44,5 @@ view address game =
 
     div []
         [ img [ src "assets/cookie.jpeg", onClick address Increment ] []
-        , div [] [text (toString game.points)]
+        , div [] [text (toString game.clicks)]
         ]

--- a/src/CookieClicker.elm
+++ b/src/CookieClicker.elm
@@ -12,8 +12,9 @@ import Effects exposing (..)
 type State = Play | Pause
 
 type alias Game =
-    { clicks : Int -- aka Cookies Clicked
+    { clicks : Float -- aka Cookies Clicked
     , level : Int
+    , level_total_exp : Int
     , cps_multiplier : Float
     } 
 
@@ -21,28 +22,57 @@ initGame : Game
 initGame = 
     { clicks = 0
     , level = 1
-    , cps_multiplier = 1.7
+    , level_total_exp = 100
+    , cps_multiplier = 1.0
     }
 
 -- Update
 
-type Action = Increment
+type Action = Increment | TimeTick
 
 ticker : Signal Action
-ticker = Signal.map (always Increment) (Time.every Time.second)
+ticker = Signal.map (always TimeTick) (Time.every Time.second)
 
 update : Action -> Game -> (Game, Effects.Effects Action)
 update action game =
     case action of
-        Increment -> ( {game | clicks = game.clicks + round (1 * game.cps_multiplier)}, Effects.none )
+        Increment -> let 
+                        clicks' = game.clicks + (1 * game.cps_multiplier)
+                        level' = 
+                            if round(game.clicks) >= game.level_total_exp then
+                                game.level + 1
+                            else
+                                game.level
+                        total_xp = 
+                            if level' > game.level then
+                                game.level_total_exp + ((level' ^ 2) * 100)
+                            else
+                                game.level_total_exp
+                        cps_multiplier' = 
+                            if level' > game.level then
+                                --level' ^ 1.1
+                                level' * (level' ^ 0.1) -- the 0 will eventually be modified by purchased items
+                            else
+                                game.cps_multiplier
+                    in
+                    ( { game | clicks = clicks'
+                             , level = level'  
+                             , level_total_exp = total_xp
+                             , cps_multiplier = cps_multiplier'
+                      }, 
+                    Effects.none )
+        TimeTick  -> 
+                    ( {game | clicks = game.clicks + (1 * game.cps_multiplier)}, Effects.none )
         -- TODO: Consider changing `round` to floor or ceiling
 
 -- View
 
 view : Signal.Address Action -> Game -> Html
 view address game = 
-
     div []
         [ img [ src "assets/cookie.jpeg", onClick address Increment ] []
-        , div [] [text (toString game.clicks)]
+        , div [] [text ("Clicks: " ++toString (round game.clicks))]
+        , div [] [text ("Level: " ++ toString game.level)]
+        , div [] [text ("Level EXP: " ++ toString game.level_total_exp)]
+        , div [] [text ("CPS: " ++ toString (game.cps_multiplier - 1))]
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,11 +1,17 @@
 module Main where
 
-import CookieClicker exposing (initGame, view, clickCookie)
+import CookieClicker exposing (initGame, view, update, ticker)
 import Html exposing (..)
-import Signal exposing (Signal, Address)
-import StartApp.Simple as StartApp
-
+import StartApp
+import Effects exposing (..)
 
 -- wire the entire application together
+app = 
+    StartApp.start { init = (initGame, Effects.none)
+                   , update = update, 
+                   , view = view, 
+                   , inputs = [ticker]
+                   }
+
 main =
-    StartApp.start { model = initGame, view = view, update = clickCookie}
+    app.html

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -8,8 +8,8 @@ import Effects exposing (..)
 -- wire the entire application together
 app = 
     StartApp.start { init = (initGame, Effects.none)
-                   , update = update, 
-                   , view = view, 
+                   , update = update
+                   , view = view
                    , inputs = [ticker]
                    }
 


### PR DESCRIPTION
- Switch to using `StartApp.start` instead of `StartApp.simple` so there's more handling over signals
- Add a ticker signal to update score every second based on ClickPerSecond (CPS) modifier
- Add level up
- Add ClickPerSecond (CPS) modifier
